### PR TITLE
Add drone `external_position` topic remapping

### DIFF
--- a/aruco_ros/src/map_single.cpp
+++ b/aruco_ros/src/map_single.cpp
@@ -106,7 +106,7 @@ public:
     debug_pub = it.advertise("debug", 1);
     pose_pub = nh.advertise<geometry_msgs::PoseStamped>("pose", 100);
     transform_pub = nh.advertise<geometry_msgs::TransformStamped>("transform", 100);
-    position_pub = nh.advertise<geometry_msgs::PointStamped>("/espdrone_106/external_position", 100);
+    position_pub = nh.advertise<geometry_msgs::PointStamped>("position", 100);
 
     nh.param<double>("marker_size", marker_size, 0.05);
     nh.param<std::string>("map_config", map_config_file, "board.yml");

--- a/espdrone_aruco_bringup/launch/espdrone_aruco.launch
+++ b/espdrone_aruco_bringup/launch/espdrone_aruco.launch
@@ -42,7 +42,14 @@
 
   </group>
 
-  <!-- ArUco mapping -->
+  <!-- ArUco mapping stuff -->
+
+  <!-- Remap 'position' topic published by 'aruco_map_pose_tracker' node into '/<drone_name>/external_position' subscribed
+       by 'espdrone_server'. This will force-update the ESP-drone's internal position estimate (since our goal is to use the
+       onboard camera and the ArUco marker map as positioning system).
+   -->
+  <remap from="/$(arg drone_name)/aruco_map_pose_tracker/position" to="/$(arg drone_name)/external_position"/>
+
   <include file="$(find aruco_ros)/launch/map.launch">
     <arg name="camera_name" value="$(arg drone_name)"/>
     <arg name="marker_size" value="$(arg aruco_marker_size)"/>


### PR DESCRIPTION
The calculated position of the camera published by `aruco_map_pose_tracker` should be remapped to `/<drone_name>/external_position` so that this calculated position updates the drone's internal position estimate. This was previously hardcoded inside `map_single.cpp`.

Otherwise, the stack is tested to be stable enough.